### PR TITLE
Default to include semantic variants in char searching

### DIFF
--- a/ytenx/templates/kiemx_sriek.html
+++ b/ytenx/templates/kiemx_sriek.html
@@ -55,7 +55,7 @@
           </label>
           <p class="help-block">如：「爲」「為」、「裏」「裡」</p>
           <label class="checkbox">
-            <input type="checkbox" name="jtkd" value="1">
+            <input type="checkbox" name="jtkd" value="1" checked="checked">
             轉換語義交疊異體字
           </label>
           <p class="help-block">如：「娘」「孃」、「吊」「弔」</p>

--- a/ytenx/templates/layout.html
+++ b/ytenx/templates/layout.html
@@ -71,6 +71,7 @@
               <input type="text" class="search-query span3" name="dzih" placeholder="在此輸入要檢索的字">
               <input type="hidden" name="dzyen" value="1">
               <input type="hidden" name="jtkb" value="1">
+              <input type="hidden" name="jtkd" value="1">
               <input type="hidden" name="jtdt" value="1">
               <input type="hidden" name="jtgt" value="1">              
             </form>


### PR DESCRIPTION
Reasonable as some close variants such as 鑽鑚 are considered semantic variants instead of z-variants