### PR TITLE
Include simplified variants of Chinese chars in search range

### DIFF
--- a/ytenx/views.py
+++ b/ytenx/views.py
@@ -63,6 +63,8 @@ def zim(request):
         if chom_sryoh['jih_thex_krenx_byan']:
           for dzih in jih_thex.byan.all():
             dzih_liet[dzih.dzih] = True
+          for dzih in jih_thex.krenx.all():
+            dzih_liet[dzih.dzih] = True            
         #Unihan所未收錄異體字
         if chom_sryoh['jih_thex_tha']:
           for dzih in jih_thex.tha.all():


### PR DESCRIPTION
Include simplified variants of Chinese chars in search range, as rhyme dictionary sometimes include Simplified Chinese characters e.g. 廣韻「虛」