### PR TITLE
Fix error in extrapolated Putonghua

### DIFF
--- a/ytenx/sync/kyonh/Dauh.txt
+++ b/ytenx/sync/kyonh/Dauh.txt
@@ -2016,7 +2016,7 @@
 2015 kʰâm kan3
 2016 ɦǎm' han4
 2017 lâm lan3
-2018 tâm tan3
+2018 tâm dan3
 2019 hâm han3
 2020 kâm gan3
 2021 ʃâm 

--- a/ytenx/sync/kyonh/Dauh.txt
+++ b/ytenx/sync/kyonh/Dauh.txt
@@ -2470,7 +2470,7 @@
 2469 hwǎ hua4
 2470 pǎi bai4
 2471 ʈʂwǎ zhuai4
-2472 kwǎi kuai4
+2472 kwǎi guai4
 2473 ʔiǎi ye4
 2474 ʈʂǎi zhai4
 2475 kiǎi jie4


### PR DESCRIPTION
The extrapolated Putonghua pronunciation of small rhyme No. 2018 (都感切) should be dan3 instead of tan3.

Small rhyme No. 2472 (古壞切) should be guai4 instead of kuai4.