### PR TITLE
Dockerfile 現代化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM python:3.7
-RUN mkdir -p /usr/src/ytenx
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 WORKDIR /usr/src/ytenx
-ADD requirements.txt /usr/src/ytenx
-RUN pip install -v -r requirements.txt
-COPY . /usr/src/ytenx
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
 EXPOSE 8000
 CMD ["gunicorn", "ytenx.wsgi", "-b", "0.0.0.0:8000"]


### PR DESCRIPTION
主要改動

1. python:3.7 → python:3.12-slim（安全更新 + 鏡像更小）
2. 加 PYTHONDONTWRITEBYTECODE / PYTHONUNBUFFERED（標準 Python 容器配置）
3. 去掉 pip install -v（-v 只是噪音），加 --no-cache-dir（減小鏡像體積）
4. ADD → COPY（ADD 有隱式解壓行爲，用 COPY 更明確）