### PR TITLE
Fix STATIC_URL missing in cio_do includes due to Django `only` keyword

### DIFF
--- a/ytenx/templates/kyonh/dzih.html
+++ b/ytenx/templates/kyonh/dzih.html
@@ -39,7 +39,7 @@
 <div class="row">
   <div class="span8">
     <h2>書影</h2>
-    {% include "kyonh/cio_do.html" with cio_do_pieux=dzih.sieuxYonh.cio.all only %}
+    {% include "kyonh/cio_do.html" with cio_do_pieux=dzih.sieuxYonh.cio.all STATIC_URL=STATIC_URL only %}
   </div>
 </div>
 

--- a/ytenx/templates/kyonh/sieux_yonh.html
+++ b/ytenx/templates/kyonh/sieux_yonh.html
@@ -136,7 +136,7 @@
 <div class="row">
   <div class="span8">
     <h2>書影</h2>
-    {% include "kyonh/cio_do.html" with cio_do_pieux=sieux_yonh.cio.all only %}
+    {% include "kyonh/cio_do.html" with cio_do_pieux=sieux_yonh.cio.all STATIC_URL=STATIC_URL only %}
   </div>
 </div>
 {% endblock %}

--- a/ytenx/templates/pyonh/dzih.html
+++ b/ytenx/templates/pyonh/dzih.html
@@ -51,7 +51,7 @@
 <div class="row">
   <div class="span8">
     <h2>書影</h2>
-    {% include "pyonh/pohpyon/cio_do.html" with cio_do_pieux=dzih.cio.all only %}
+    {% include "pyonh/pohpyon/cio_do.html" with cio_do_pieux=dzih.cio.all STATIC_URL=STATIC_URL only %}
   </div>
 </div>
 {% endblock %}

--- a/ytenx/templates/pyonh/sieux_yonh.html
+++ b/ytenx/templates/pyonh/sieux_yonh.html
@@ -61,7 +61,7 @@
 <div class="row">
   <div class="span8">
     <h2>書影</h2>
-    {% include "pyonh/pohpyon/cio_do.html" with cio_do_pieux=sieux_yonh.cio.all only %}
+    {% include "pyonh/pohpyon/cio_do.html" with cio_do_pieux=sieux_yonh.cio.all STATIC_URL=STATIC_URL only %}
   </div>
 </div>
 {% endblock %}

--- a/ytenx/templates/trngyan/dzih.html
+++ b/ytenx/templates/trngyan/dzih.html
@@ -51,7 +51,7 @@
 <div class="row">
   <div class="span8">
     <h2>書影</h2>
-    {% include "trngyan/pohpyon/cio_do.html" with cio_do_pieux=dzih.cio.all only %}
+    {% include "trngyan/pohpyon/cio_do.html" with cio_do_pieux=dzih.cio.all STATIC_URL=STATIC_URL only %}
   </div>
 </div>
 {% endblock %}

--- a/ytenx/templates/trngyan/sieux_yonh.html
+++ b/ytenx/templates/trngyan/sieux_yonh.html
@@ -79,7 +79,7 @@
   <div class="row">
     <div class="span8">
       <h2>書影</h2>
-      {% include "trngyan/pohpyon/cio_do.html" with cio_do_pieux=sieux_yonh.cio.all only %}
+      {% include "trngyan/pohpyon/cio_do.html" with cio_do_pieux=sieux_yonh.cio.all STATIC_URL=STATIC_URL only %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
Pass STATIC_URL explicitly in six include tags across trngyan, kyonh, and pyonh templates, where the 'only' modifier was stripping context processor variables and producing relative image URLs.

<img width="728" height="781" alt="image" src="https://github.com/user-attachments/assets/f4b2f396-1329-4db7-a8ca-609d32b87c16" />
