### PR TITLE
Add remastered Thousand Character Classic links

### DIFF
--- a/ytenx/templates/byohlyuk/YonhMyon.html
+++ b/ytenx/templates/byohlyuk/YonhMyon.html
@@ -16,8 +16,8 @@
 <table class="table">
 <tr>
   <th>名稱</th>
-  <th>優酷鏈接</th>
-  <th>Youtube鏈接</th>
+  <th>中國大陸影片連結</th>
+  <th>Youtube連結</th>
   <th>日期</th>
   <th>作者</th>
 </tr>
@@ -30,6 +30,18 @@
   </td>
 
   <td>2010年07月21日</td>
+  <td>polyhedron</td>
+</tr>
+<tr>
+  <td>千字文（2026年重制版）</td>
+  <td>
+    <a href="https://www.bilibili.com/video/BV1UQTJ69EK8/" target="_blank">Bilibili</a>
+  </td>
+  <td>
+    <a href="https://www.youtube.com/watch?v=VJh-cFsmQX0" target="_blank">Youtube</a>
+  </td>
+
+  <td>2026年07月02日</td>
   <td>polyhedron</td>
 </tr>
 <tr>


### PR DESCRIPTION
Add the 2026 remastered Thousand Character Classic video links to the Middle Chinese reading page. Also update the media column headers to match the current wording used by the related tutorial page.